### PR TITLE
Use localstack on CI 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,8 +3,6 @@
 # Check https://circleci.com/docs/2.0/language-clojure/ for more details
 #
 version: 2.1
-# orbs:
-#   wait-for: cobli/wait-for@0.0.2
 jobs:
   jvm:
     docker:
@@ -33,8 +31,6 @@ jobs:
             wget -nc https://download.clojure.org/install/linux-install-1.10.1.727.sh
             chmod +x linux-install-1.10.1.727.sh
             sudo ./linux-install-1.10.1.727.sh
-      # - wait-for/localstack-s3:
-      #     port: 4566
       - run:
           name: Run JVM tests
           environment:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,11 +3,16 @@
 # Check https://circleci.com/docs/2.0/language-clojure/ for more details
 #
 version: 2.1
+# orbs:
+#   wait-for: cobli/wait-for@0.0.2
 jobs:
   jvm:
     docker:
       # specify the version you desire here
       - image: circleci/clojure:lein-2.9.3-buster
+      - image: localstack/localstack
+        environment:
+          SERVICES: s3
     working_directory: ~/repo
     environment:
       LEIN_ROOT: "true"
@@ -28,8 +33,14 @@ jobs:
             wget -nc https://download.clojure.org/install/linux-install-1.10.1.727.sh
             chmod +x linux-install-1.10.1.727.sh
             sudo ./linux-install-1.10.1.727.sh
+      # - wait-for/localstack-s3:
+      #     port: 4566
       - run:
           name: Run JVM tests
+          environment:
+            AWS_ACCESS_KEY_ID: test
+            AWS_SECRET_ACCESS_KEY: test
+            AWS_REGION: eu-west-1
           command: |
             script/test
       - save_cache:
@@ -39,6 +50,9 @@ jobs:
   linux:
     docker:
       - image: circleci/clojure:lein-2.9.3-buster
+      - image: localstack/localstack
+        environment:
+          SERVICES: s3
     working_directory: ~/repo
     environment:
       LEIN_ROOT: "true"
@@ -86,6 +100,10 @@ jobs:
               --dir bb --download-dir bb
       - run:
           name: Run test
+          environment:
+            AWS_ACCESS_KEY_ID: test
+            AWS_SECRET_ACCESS_KEY: test
+            AWS_REGION: eu-west-1
           command: PATH=$PATH:bb script/test
       - run:
           name: Release

--- a/README.md
+++ b/README.md
@@ -68,6 +68,17 @@ To test the pod code with JVM clojure, run `clojure -M test/script.clj`.
 
 To test the native image with bb, run `bb test/script.clj`.
 
+To test with [localstack](https://github.com/localstack/localstack)
+
+``` shell
+# Start localstack
+docker-compose up -d
+
+# Set test credentials and run tests
+AWS_REGION=eu-north-1 AWS_ACCESS_KEY_ID=test AWS_SECRET_ACCESS_KEY=test script/test
+```
+
+
 ## License
 
 Copyright © 2020 Michiel Borkent, Jeroen van Dijk, Rahul De and Valtteri Harmainen.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,18 @@
+version: '2.1'
+
+services:
+  localstack:
+    container_name: "${LOCALSTACK_DOCKER_NAME-localstack_main}"
+    image: localstack/localstack
+    network_mode: bridge
+    ports:
+      - "4566:4566"
+      - "4571:4571"
+      - "${PORT_WEB_UI-8080}:${PORT_WEB_UI-8080}"
+    environment:
+      - SERVICES=${SERVICES-s3}
+      - DOCKER_HOST=unix:///var/run/docker.sock
+      - HOST_TMP_FOLDER=${TMPDIR}
+    volumes:
+      - "${TMPDIR:-/tmp/localstack}:/tmp/localstack"
+      - "/var/run/docker.sock:/var/run/docker.sock"

--- a/test/script.clj
+++ b/test/script.clj
@@ -22,9 +22,17 @@
 
 (require '[pod.babashka.aws :as aws])
 
+;; TODO maybe less implicit config for this
+(defn localstack? []
+  (= "test" (System/getenv "AWS_ACCESS_KEY_ID") (System/getenv "AWS_SECRET_ACCESS_KEY")))
+
+(def localstack-endpoint {:protocol :http :hostname "localhost" :port 4566})
+
 (def region (System/getenv "AWS_REGION"))
-(def s3 (aws/client {:api :s3 :region
-                     (or region "eu-central-1")}))
+(def s3 (aws/client (merge
+                     {:api :s3 :region (or region "eu-central-1") }
+                     (when (localstack?)
+                       {:endpoint-override localstack-endpoint}))))
 
 (deftest aws-ops-test
   (is (contains? (aws/ops s3) :ListBuckets)))


### PR DESCRIPTION
Use localstack on CI to simulate AWS during tests.

Currently localstack is used on:
- docker
- linux

It can be added to mac build as well once someone figures out how to do it.

Test script has been updated to detect _implicitly_ if localstack is used. If env vars `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` equal to `test`, then tests override endpoint to call localstack instead of 'real aws'.

Also added `docker-compose.yml` and instructions to `readme.md` for running localstack locally.

fixes #4 