### PR TITLE
Improve deps.edn output for readability

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -15,264 +15,262 @@
         babashka/pods {:git/url "https://github.com/babashka/pods"
                        :sha "22f200ef3006da90971e3bafa794985918b65fea"}
         ;; from https://raw.githubusercontent.com/cognitect-labs/aws-api/master/latest-releases.edn
-        com.cognitect.aws/AWS242AppRegistry {:mvn/version "810.2.817.0", :aws/serviceFullName "AWS Service Catalog App Registry"}
-        com.cognitect.aws/AWSMigrationHub {:mvn/version "796.2.657.0", :aws/serviceFullName "AWS Migration Hub"}
-        com.cognitect.aws/accessanalyzer {:mvn/version "809.2.784.0", :aws/serviceFullName "Access Analyzer"}
-        com.cognitect.aws/acm {:mvn/version "809.2.784.0", :aws/serviceFullName "AWS Certificate Manager"}
-        com.cognitect.aws/acm-pca {:mvn/version "811.2.824.0", :aws/serviceFullName "AWS Certificate Manager Private Certificate Authority"}
-        com.cognitect.aws/alexaforbusiness {:mvn/version "802.2.713.0", :aws/serviceFullName "Alexa For Business"}
-        com.cognitect.aws/amp {:mvn/version "810.2.817.0", :aws/serviceFullName "Amazon Prometheus Service"}
-        com.cognitect.aws/amplify {:mvn/version "809.2.797.0", :aws/serviceFullName "AWS Amplify"}
-        com.cognitect.aws/amplifybackend {:mvn/version "810.2.805.0", :aws/serviceFullName "AmplifyBackend"}
-        com.cognitect.aws/api {:mvn/version "0.8.498"}
-        com.cognitect.aws/apigateway {:mvn/version "810.2.817.0", :aws/serviceFullName "Amazon API Gateway"}
-        com.cognitect.aws/apigatewaymanagementapi {:mvn/version "770.2.568.0", :aws/serviceFullName "AmazonApiGatewayManagementApi"}
-        com.cognitect.aws/apigatewayv2 {:mvn/version "811.2.824.0", :aws/serviceFullName "AmazonApiGatewayV2"}
-        com.cognitect.aws/appconfig {:mvn/version "801.2.697.0", :aws/serviceFullName "Amazon AppConfig"}
-        com.cognitect.aws/appflow {:mvn/version "810.2.801.0", :aws/serviceFullName "Amazon Appflow"}
-        com.cognitect.aws/appintegrations {:mvn/version "810.2.801.0", :aws/serviceFullName "Amazon AppIntegrations Service"}
-        com.cognitect.aws/application-autoscaling {:mvn/version "811.2.824.0", :aws/serviceFullName "Application Auto Scaling"}
-        com.cognitect.aws/application-insights {:mvn/version "810.2.801.0", :aws/serviceFullName "Amazon CloudWatch Application Insights"}
-        com.cognitect.aws/appmesh {:mvn/version "809.2.797.0", :aws/serviceFullName "AWS App Mesh"}
-        com.cognitect.aws/appstream {:mvn/version "809.2.734.0", :aws/serviceFullName "Amazon AppStream"}
-        com.cognitect.aws/appsync {:mvn/version "809.2.784.0", :aws/serviceFullName "AWS AppSync"}
-        com.cognitect.aws/athena {:mvn/version "801.2.687.0", :aws/serviceFullName "Amazon Athena"}
-        com.cognitect.aws/auditmanager {:mvn/version "810.2.817.0", :aws/serviceFullName "AWS Audit Manager"}
-        com.cognitect.aws/autoscaling {:mvn/version "811.2.824.0", :aws/serviceFullName "Auto Scaling"}
-        com.cognitect.aws/autoscaling-plans {:mvn/version "811.2.824.0", :aws/serviceFullName "AWS Auto Scaling Plans"}
-        com.cognitect.aws/backup {:mvn/version "809.2.797.0", :aws/serviceFullName "AWS Backup"}
-        com.cognitect.aws/batch {:mvn/version "810.2.817.0", :aws/serviceFullName "AWS Batch"}
-        com.cognitect.aws/braket {:mvn/version "810.2.797.0", :aws/serviceFullName "Braket"}
-        com.cognitect.aws/budgets {:mvn/version "809.2.784.0", :aws/serviceFullName "AWS Budgets"}
-        com.cognitect.aws/ce {:mvn/version "811.2.824.0", :aws/serviceFullName "AWS Cost Explorer Service"}
-        com.cognitect.aws/chime {:mvn/version "809.2.797.0", :aws/serviceFullName "Amazon Chime"}
-        com.cognitect.aws/cloud9 {:mvn/version "809.2.734.0", :aws/serviceFullName "AWS Cloud9"}
-        com.cognitect.aws/clouddirectory {:mvn/version "770.2.568.0", :aws/serviceFullName "Amazon CloudDirectory"}
-        com.cognitect.aws/cloudformation {:mvn/version "810.2.801.0", :aws/serviceFullName "AWS CloudFormation"}
-        com.cognitect.aws/cloudfront {:mvn/version "811.2.824.0", :aws/serviceFullName "Amazon CloudFront"}
-        com.cognitect.aws/cloudhsm {:mvn/version "770.2.568.0", :aws/serviceFullName "Amazon CloudHSM"}
-        com.cognitect.aws/cloudhsmv2 {:mvn/version "809.2.797.0", :aws/serviceFullName "AWS CloudHSM V2"}
-        com.cognitect.aws/cloudsearch {:mvn/version "811.2.824.0", :aws/serviceFullName "Amazon CloudSearch"}
-        com.cognitect.aws/cloudsearchdomain {:mvn/version "770.2.568.0", :aws/serviceFullName "Amazon CloudSearch Domain"}
-        com.cognitect.aws/cloudtrail {:mvn/version "810.2.817.0", :aws/serviceFullName "AWS CloudTrail"}
-        com.cognitect.aws/codeartifact {:mvn/version "810.2.801.0", :aws/serviceFullName "CodeArtifact"}
-        com.cognitect.aws/codebuild {:mvn/version "810.2.802.0", :aws/serviceFullName "AWS CodeBuild"}
-        com.cognitect.aws/codecommit {:mvn/version "801.2.704.0", :aws/serviceFullName "AWS CodeCommit"}
-        com.cognitect.aws/codedeploy {:mvn/version "799.2.681.0", :aws/serviceFullName "AWS CodeDeploy"}
-        com.cognitect.aws/codeguru-reviewer {:mvn/version "809.2.797.0", :aws/serviceFullName "Amazon CodeGuru Reviewer"}
-        com.cognitect.aws/codeguruprofiler {:mvn/version "803.2.717.0", :aws/serviceFullName "Amazon CodeGuru Profiler"}
-        com.cognitect.aws/codepipeline {:mvn/version "811.2.824.0", :aws/serviceFullName "AWS CodePipeline"}
-        com.cognitect.aws/codestar {:mvn/version "770.2.568.0", :aws/serviceFullName "AWS CodeStar"}
-        com.cognitect.aws/codestar-connections {:mvn/version "810.2.801.0", :aws/serviceFullName "AWS CodeStar connections"}
-        com.cognitect.aws/codestar-notifications {:mvn/version "770.2.568.0", :aws/serviceFullName "AWS CodeStar Notifications"}
-        com.cognitect.aws/cognito-identity {:mvn/version "809.2.797.0", :aws/serviceFullName "Amazon Cognito Identity"}
-        com.cognitect.aws/cognito-idp {:mvn/version "810.2.801.0", :aws/serviceFullName "Amazon Cognito Identity Provider"}
-        com.cognitect.aws/cognito-sync {:mvn/version "770.2.568.0", :aws/serviceFullName "Amazon Cognito Sync"}
-        com.cognitect.aws/comprehend {:mvn/version "810.2.801.0", :aws/serviceFullName "Amazon Comprehend"}
-        com.cognitect.aws/comprehendmedical {:mvn/version "801.2.708.0", :aws/serviceFullName "AWS Comprehend Medical"}
-        com.cognitect.aws/compute-optimizer {:mvn/version "810.2.817.0", :aws/serviceFullName "AWS Compute Optimizer"}
-        com.cognitect.aws/config {:mvn/version "810.2.817.0", :aws/serviceFullName "AWS Config"}
-        com.cognitect.aws/connect {:mvn/version "810.2.817.0", :aws/serviceFullName "Amazon Connect Service"}
-        com.cognitect.aws/connect-contact-lens {:mvn/version "810.2.801.0", :aws/serviceFullName "Amazon Connect Contact Lens"}
-        com.cognitect.aws/connectparticipant {:mvn/version "810.2.817.0", :aws/serviceFullName "Amazon Connect Participant Service"}
-        com.cognitect.aws/cur {:mvn/version "809.2.784.0", :aws/serviceFullName "AWS Cost and Usage Report Service"}
-        com.cognitect.aws/customer-profiles {:mvn/version "810.2.802.0", :aws/serviceFullName "Amazon Connect Customer Profiles"}
-        com.cognitect.aws/databrew {:mvn/version "810.2.797.0", :aws/serviceFullName "AWS Glue DataBrew"}
-        com.cognitect.aws/dataexchange {:mvn/version "801.2.698.0", :aws/serviceFullName "AWS Data Exchange"}
-        com.cognitect.aws/datapipeline {:mvn/version "770.2.568.0", :aws/serviceFullName "AWS Data Pipeline"}
-        com.cognitect.aws/datasync {:mvn/version "809.2.797.0", :aws/serviceFullName "AWS DataSync"}
-        com.cognitect.aws/dax {:mvn/version "770.2.568.0", :aws/serviceFullName "Amazon DynamoDB Accelerator (DAX)"}
-        com.cognitect.aws/detective {:mvn/version "796.2.650.0", :aws/serviceFullName "Amazon Detective"}
-        com.cognitect.aws/devicefarm {:mvn/version "784.2.595.0", :aws/serviceFullName "AWS Device Farm"}
-        com.cognitect.aws/devices {:mvn/version "770.2.568.0", :aws/serviceFullName "AWS IoT 1-Click Devices Service"}
-        com.cognitect.aws/devops-guru {:mvn/version "811.2.824.0", :aws/serviceFullName "Amazon DevOps Guru"}
-        com.cognitect.aws/directconnect {:mvn/version "809.2.784.0", :aws/serviceFullName "AWS Direct Connect"}
-        com.cognitect.aws/discovery {:mvn/version "788.2.608.0", :aws/serviceFullName "AWS Application Discovery Service"}
-        com.cognitect.aws/dlm {:mvn/version "810.2.817.0", :aws/serviceFullName "Amazon Data Lifecycle Manager"}
-        com.cognitect.aws/dms {:mvn/version "810.2.817.0", :aws/serviceFullName "AWS Database Migration Service"}
-        com.cognitect.aws/docdb {:mvn/version "809.2.784.0", :aws/serviceFullName "Amazon DocumentDB with MongoDB compatibility"}
-        com.cognitect.aws/ds {:mvn/version "810.2.805.0", :aws/serviceFullName "AWS Directory Service"}
-        com.cognitect.aws/dynamodb {:mvn/version "810.2.801.0", :aws/serviceFullName "Amazon DynamoDB"}
-        com.cognitect.aws/ebs {:mvn/version "809.2.784.0", :aws/serviceFullName "Amazon Elastic Block Store"}
-        com.cognitect.aws/ec2 {:mvn/version "810.2.817.0", :aws/serviceFullName "Amazon Elastic Compute Cloud"}
-        com.cognitect.aws/ec2-instance-connect {:mvn/version "770.2.568.0", :aws/serviceFullName "AWS EC2 Instance Connect"}
-        com.cognitect.aws/ecr {:mvn/version "810.2.817.0", :aws/serviceFullName "Amazon EC2 Container Registry"}
-        com.cognitect.aws/ecr-public {:mvn/version "810.2.801.0", :aws/serviceFullName "Amazon Elastic Container Registry Public"}
-        com.cognitect.aws/ecs {:mvn/version "810.2.801.0", :aws/serviceFullName "Amazon EC2 Container Service"}
-        com.cognitect.aws/eks {:mvn/version "810.2.801.0", :aws/serviceFullName "Amazon Elastic Kubernetes Service"}
-        com.cognitect.aws/elastic-inference {:mvn/version "796.2.663.0", :aws/serviceFullName "Amazon Elastic  Inference"}
-        com.cognitect.aws/elasticache {:mvn/version "811.2.824.0", :aws/serviceFullName "Amazon ElastiCache"}
-        com.cognitect.aws/elasticbeanstalk {:mvn/version "810.2.801.0", :aws/serviceFullName "AWS Elastic Beanstalk"}
-        com.cognitect.aws/elasticfilesystem {:mvn/version "802.2.711.0", :aws/serviceFullName "Amazon Elastic File System"}
-        com.cognitect.aws/elasticloadbalancing {:mvn/version "809.2.784.0", :aws/serviceFullName "Elastic Load Balancing"}
-        com.cognitect.aws/elasticloadbalancingv2 {:mvn/version "809.2.797.0", :aws/serviceFullName "Elastic Load Balancing"}
-        com.cognitect.aws/elasticmapreduce {:mvn/version "810.2.801.0", :aws/serviceFullName "Amazon Elastic MapReduce"}
-        com.cognitect.aws/elastictranscoder {:mvn/version "770.2.568.0", :aws/serviceFullName "Amazon Elastic Transcoder"}
-        com.cognitect.aws/email {:mvn/version "770.2.568.0", :aws/serviceFullName "Amazon Simple Email Service"}
-        com.cognitect.aws/emr-containers {:mvn/version "810.2.817.0", :aws/serviceFullName "Amazon EMR Containers"}
-        com.cognitect.aws/endpoints {:mvn/version "1.1.11.934"}
-        com.cognitect.aws/entitlement-marketplace {:mvn/version "770.2.568.0", :aws/serviceFullName "AWS Marketplace Entitlement Service"}
-        com.cognitect.aws/es {:mvn/version "809.2.797.0", :aws/serviceFullName "Amazon Elasticsearch Service"}
-        com.cognitect.aws/eventbridge {:mvn/version "809.2.797.0", :aws/serviceFullName "Amazon EventBridge"}
-        com.cognitect.aws/events {:mvn/version "809.2.797.0", :aws/serviceFullName "Amazon CloudWatch Events"}
-        com.cognitect.aws/firehose {:mvn/version "807.2.729.0", :aws/serviceFullName "Amazon Kinesis Firehose"}
-        com.cognitect.aws/fms {:mvn/version "809.2.797.0", :aws/serviceFullName "Firewall Management Service"}
-        com.cognitect.aws/forecast {:mvn/version "810.2.817.0", :aws/serviceFullName "Amazon Forecast Service"}
-        com.cognitect.aws/forecastquery {:mvn/version "789.2.612.0", :aws/serviceFullName "Amazon Forecast Query Service"}
-        com.cognitect.aws/frauddetector {:mvn/version "809.2.797.0", :aws/serviceFullName "Amazon Fraud Detector"}
-        com.cognitect.aws/fsx {:mvn/version "810.2.801.0", :aws/serviceFullName "Amazon FSx"}
-        com.cognitect.aws/gamelift {:mvn/version "810.2.801.0", :aws/serviceFullName "Amazon GameLift"}
-        com.cognitect.aws/glacier {:mvn/version "770.2.568.0", :aws/serviceFullName "Amazon Glacier"}
-        com.cognitect.aws/globalaccelerator {:mvn/version "810.2.817.0", :aws/serviceFullName "AWS Global Accelerator"}
-        com.cognitect.aws/glue {:mvn/version "810.2.817.0", :aws/serviceFullName "AWS Glue"}
-        com.cognitect.aws/greengrass {:mvn/version "809.2.784.0", :aws/serviceFullName "AWS Greengrass"}
-        com.cognitect.aws/greengrassv2 {:mvn/version "810.2.817.0", :aws/serviceFullName "AWS IoT Greengrass V2"}
-        com.cognitect.aws/groundstation {:mvn/version "809.2.784.0", :aws/serviceFullName "AWS Ground Station"}
-        com.cognitect.aws/guardduty {:mvn/version "810.2.817.0", :aws/serviceFullName "Amazon GuardDuty"}
-        com.cognitect.aws/health {:mvn/version "807.2.729.0", :aws/serviceFullName "AWS Health APIs and Notifications"}
-        com.cognitect.aws/healthlake {:mvn/version "811.2.824.0", :aws/serviceFullName "Amazon HealthLake"}
-        com.cognitect.aws/honeycode {:mvn/version "810.2.801.0", :aws/serviceFullName "Amazon Honeycode"}
-        com.cognitect.aws/iam {:mvn/version "801.2.704.0", :aws/serviceFullName "AWS Identity and Access Management"}
-        com.cognitect.aws/identitystore {:mvn/version "810.2.797.0", :aws/serviceFullName "AWS SSO Identity Store"}
-        com.cognitect.aws/imagebuilder {:mvn/version "810.2.817.0", :aws/serviceFullName "EC2 Image Builder"}
-        com.cognitect.aws/importexport {:mvn/version "770.2.568.0", :aws/serviceFullName "AWS Import/Export"}
-        com.cognitect.aws/inspector {:mvn/version "770.2.568.0", :aws/serviceFullName "Amazon Inspector"}
-        com.cognitect.aws/iot {:mvn/version "810.2.817.0", :aws/serviceFullName "AWS IoT"}
-        com.cognitect.aws/iot-data {:mvn/version "801.2.695.0", :aws/serviceFullName "AWS IoT Data Plane"}
-        com.cognitect.aws/iot-jobs-data {:mvn/version "770.2.568.0", :aws/serviceFullName "AWS IoT Jobs Data Plane"}
-        com.cognitect.aws/iot1click-projects {:mvn/version "770.2.568.0", :aws/serviceFullName "AWS IoT 1-Click Projects Service"}
-        com.cognitect.aws/iotanalytics {:mvn/version "810.2.817.0", :aws/serviceFullName "AWS IoT Analytics"}
-        com.cognitect.aws/iotdeviceadvisor {:mvn/version "810.2.817.0", :aws/serviceFullName "AWS IoT Core Device Advisor"}
-        com.cognitect.aws/iotevents {:mvn/version "796.2.667.0", :aws/serviceFullName "AWS IoT Events"}
-        com.cognitect.aws/iotevents-data {:mvn/version "770.2.568.0", :aws/serviceFullName "AWS IoT Events Data"}
-        com.cognitect.aws/iotfleethub {:mvn/version "810.2.817.0", :aws/serviceFullName "AWS IoT Fleet Hub"}
-        com.cognitect.aws/iotsecuretunneling {:mvn/version "809.2.797.0", :aws/serviceFullName "AWS IoT Secure Tunneling"}
-        com.cognitect.aws/iotsitewise {:mvn/version "810.2.817.0", :aws/serviceFullName "AWS IoT SiteWise"}
-        com.cognitect.aws/iotthingsgraph {:mvn/version "770.2.568.0", :aws/serviceFullName "AWS IoT Things Graph"}
-        com.cognitect.aws/iotwireless {:mvn/version "810.2.817.0", :aws/serviceFullName "AWS IoT Wireless"}
-        com.cognitect.aws/ivs {:mvn/version "809.2.784.0", :aws/serviceFullName "Amazon Interactive Video Service"}
-        com.cognitect.aws/kafka {:mvn/version "810.2.805.0", :aws/serviceFullName "Managed Streaming for Kafka"}
-        com.cognitect.aws/kendra {:mvn/version "810.2.817.0", :aws/serviceFullName "AWSKendraFrontendService"}
-        com.cognitect.aws/kinesis {:mvn/version "809.2.784.0", :aws/serviceFullName "Amazon Kinesis"}
-        com.cognitect.aws/kinesis-video-archived-media {:mvn/version "796.2.665.0", :aws/serviceFullName "Amazon Kinesis Video Streams Archived Media"}
-        com.cognitect.aws/kinesis-video-media {:mvn/version "770.2.568.0", :aws/serviceFullName "Amazon Kinesis Video Streams Media"}
-        com.cognitect.aws/kinesis-video-signaling {:mvn/version "781.2.585.0", :aws/serviceFullName "Amazon Kinesis Video Signaling Channels"}
-        com.cognitect.aws/kinesisanalytics {:mvn/version "770.2.568.0", :aws/serviceFullName "Amazon Kinesis Analytics"}
-        com.cognitect.aws/kinesisanalyticsv2 {:mvn/version "809.2.797.0", :aws/serviceFullName "Amazon Kinesis Analytics"}
-        com.cognitect.aws/kinesisvideo {:mvn/version "796.2.665.0", :aws/serviceFullName "Amazon Kinesis Video Streams"}
-        com.cognitect.aws/kms {:mvn/version "810.2.817.0", :aws/serviceFullName "AWS Key Management Service"}
-        com.cognitect.aws/lakeformation {:mvn/version "809.2.784.0", :aws/serviceFullName "AWS Lake Formation"}
-        com.cognitect.aws/lambda {:mvn/version "810.2.817.0", :aws/serviceFullName "AWS Lambda"}
-        com.cognitect.aws/lex-models {:mvn/version "810.2.801.0", :aws/serviceFullName "Amazon Lex Model Building Service"}
-        com.cognitect.aws/license-manager {:mvn/version "810.2.805.0", :aws/serviceFullName "AWS License Manager"}
-        com.cognitect.aws/lightsail {:mvn/version "809.2.797.0", :aws/serviceFullName "Amazon Lightsail"}
-        com.cognitect.aws/location {:mvn/version "810.2.817.0", :aws/serviceFullName "Amazon Location Service"}
-        com.cognitect.aws/logs {:mvn/version "809.2.784.0", :aws/serviceFullName "Amazon CloudWatch Logs"}
-        com.cognitect.aws/lookoutvision {:mvn/version "810.2.801.0", :aws/serviceFullName "Amazon Lookout for Vision"}
-        com.cognitect.aws/machinelearning {:mvn/version "770.2.568.0", :aws/serviceFullName "Amazon Machine Learning"}
-        com.cognitect.aws/macie {:mvn/version "801.2.684.0", :aws/serviceFullName "Amazon Macie"}
-        com.cognitect.aws/macie2 {:mvn/version "811.2.824.0", :aws/serviceFullName "Amazon Macie 2"}
-        com.cognitect.aws/managedblockchain {:mvn/version "810.2.817.0", :aws/serviceFullName "Amazon Managed Blockchain"}
-        com.cognitect.aws/marketplace-catalog {:mvn/version "809.2.784.0", :aws/serviceFullName "AWS Marketplace Catalog Service"}
-        com.cognitect.aws/marketplacecommerceanalytics {:mvn/version "809.2.784.0", :aws/serviceFullName "AWS Marketplace Commerce Analytics"}
-        com.cognitect.aws/mediaconnect {:mvn/version "809.2.784.0", :aws/serviceFullName "AWS MediaConnect"}
-        com.cognitect.aws/mediaconvert {:mvn/version "811.2.824.0", :aws/serviceFullName "AWS Elemental MediaConvert"}
-        com.cognitect.aws/medialive {:mvn/version "810.2.805.0", :aws/serviceFullName "AWS Elemental MediaLive"}
-        com.cognitect.aws/mediapackage {:mvn/version "809.2.784.0", :aws/serviceFullName "AWS Elemental MediaPackage"}
-        com.cognitect.aws/mediapackage-vod {:mvn/version "801.2.690.0", :aws/serviceFullName "AWS Elemental MediaPackage VOD"}
-        com.cognitect.aws/mediastore {:mvn/version "796.2.650.0", :aws/serviceFullName "AWS Elemental MediaStore"}
-        com.cognitect.aws/mediastore-data {:mvn/version "770.2.568.0", :aws/serviceFullName "AWS Elemental MediaStore Data Plane"}
-        com.cognitect.aws/mediatailor {:mvn/version "809.2.784.0", :aws/serviceFullName "AWS MediaTailor"}
-        com.cognitect.aws/meteringmarketplace {:mvn/version "809.2.797.0", :aws/serviceFullName "AWSMarketplace Metering"}
-        com.cognitect.aws/migrationhub-config {:mvn/version "796.2.656.0", :aws/serviceFullName "AWS Migration Hub Config"}
-        com.cognitect.aws/mobile {:mvn/version "770.2.568.0", :aws/serviceFullName "AWS Mobile"}
-        com.cognitect.aws/mobileanalytics {:mvn/version "770.2.568.0", :aws/serviceFullName "Amazon Mobile Analytics"}
-        com.cognitect.aws/monitoring {:mvn/version "810.2.817.0", :aws/serviceFullName "Amazon CloudWatch"}
-        com.cognitect.aws/mq {:mvn/version "809.2.797.0", :aws/serviceFullName "AmazonMQ"}
-        com.cognitect.aws/mturk-requester {:mvn/version "770.2.568.0", :aws/serviceFullName "Amazon Mechanical Turk"}
-        com.cognitect.aws/mwaa {:mvn/version "810.2.801.0", :aws/serviceFullName "AmazonMWAA"}
-        com.cognitect.aws/neptune {:mvn/version "809.2.784.0", :aws/serviceFullName "Amazon Neptune"}
-        com.cognitect.aws/network-firewall {:mvn/version "810.2.797.0", :aws/serviceFullName "AWS Network Firewall"}
-        com.cognitect.aws/networkmanager {:mvn/version "810.2.817.0", :aws/serviceFullName "AWS Network Manager"}
-        com.cognitect.aws/opsworks {:mvn/version "770.2.568.0", :aws/serviceFullName "AWS OpsWorks"}
-        com.cognitect.aws/opsworkscm {:mvn/version "801.2.701.0", :aws/serviceFullName "AWS OpsWorks CM"}
-        com.cognitect.aws/organizations {:mvn/version "809.2.784.0", :aws/serviceFullName "AWS Organizations"}
-        com.cognitect.aws/outposts {:mvn/version "810.2.817.0", :aws/serviceFullName "AWS Outposts"}
-        com.cognitect.aws/personalize {:mvn/version "807.2.729.0", :aws/serviceFullName "Amazon Personalize"}
-        com.cognitect.aws/personalize-events {:mvn/version "809.2.784.0", :aws/serviceFullName "Amazon Personalize Events"}
-        com.cognitect.aws/personalize-runtime {:mvn/version "810.2.817.0", :aws/serviceFullName "Amazon Personalize Runtime"}
-        com.cognitect.aws/pi {:mvn/version "810.2.817.0", :aws/serviceFullName "AWS Performance Insights"}
-        com.cognitect.aws/pinpoint {:mvn/version "809.2.784.0", :aws/serviceFullName "Amazon Pinpoint"}
-        com.cognitect.aws/pinpoint-email {:mvn/version "770.2.568.0", :aws/serviceFullName "Amazon Pinpoint Email Service"}
-        com.cognitect.aws/pinpoint-sms-voice {:mvn/version "770.2.568.0", :aws/serviceFullName "Amazon Pinpoint SMS and Voice Service"}
-        com.cognitect.aws/polly {:mvn/version "809.2.797.0", :aws/serviceFullName "Amazon Polly"}
-        com.cognitect.aws/pricing {:mvn/version "770.2.568.0", :aws/serviceFullName "AWS Price List Service"}
-        com.cognitect.aws/qldb {:mvn/version "801.2.698.0", :aws/serviceFullName "Amazon QLDB"}
-        com.cognitect.aws/qldb-session {:mvn/version "810.2.817.0", :aws/serviceFullName "Amazon QLDB Session"}
-        com.cognitect.aws/quicksight {:mvn/version "810.2.817.0", :aws/serviceFullName "Amazon QuickSight"}
-        com.cognitect.aws/ram {:mvn/version "796.2.662.0", :aws/serviceFullName "AWS Resource Access Manager"}
-        com.cognitect.aws/rds {:mvn/version "810.2.817.0", :aws/serviceFullName "Amazon Relational Database Service"}
-        com.cognitect.aws/rds-data {:mvn/version "795.2.645.0", :aws/serviceFullName "AWS RDS DataService"}
-        com.cognitect.aws/redshift {:mvn/version "810.2.817.0", :aws/serviceFullName "Amazon Redshift"}
-        com.cognitect.aws/redshift-data {:mvn/version "810.2.801.0", :aws/serviceFullName "Redshift Data API Service"}
-        com.cognitect.aws/rekognition {:mvn/version "809.2.784.0", :aws/serviceFullName "Amazon Rekognition"}
-        com.cognitect.aws/resource-groups {:mvn/version "810.2.817.0", :aws/serviceFullName "AWS Resource Groups"}
-        com.cognitect.aws/resourcegroupstaggingapi {:mvn/version "809.2.784.0", :aws/serviceFullName "AWS Resource Groups Tagging API"}
-        com.cognitect.aws/robomaker {:mvn/version "809.2.797.0", :aws/serviceFullName "AWS RoboMaker"}
-        com.cognitect.aws/route53 {:mvn/version "810.2.817.0", :aws/serviceFullName "Amazon Route 53"}
-        com.cognitect.aws/route53domains {:mvn/version "796.2.660.0", :aws/serviceFullName "Amazon Route 53 Domains"}
-        com.cognitect.aws/route53resolver {:mvn/version "810.2.817.0", :aws/serviceFullName "Amazon Route 53 Resolver"}
-        com.cognitect.aws/runtime-lex {:mvn/version "809.2.797.0", :aws/serviceFullName "Amazon Lex Runtime Service"}
-        com.cognitect.aws/runtime-sagemaker {:mvn/version "810.2.817.0", :aws/serviceFullName "Amazon SageMaker Runtime"}
-        com.cognitect.aws/s3 {:mvn/version "810.2.817.0", :aws/serviceFullName "Amazon Simple Storage Service"}
-        com.cognitect.aws/s3control {:mvn/version "809.2.797.0", :aws/serviceFullName "AWS S3 Control"}
-        com.cognitect.aws/s3outposts {:mvn/version "810.2.797.0", :aws/serviceFullName "Amazon S3 on Outposts"}
-        com.cognitect.aws/sagemaker {:mvn/version "810.2.817.0", :aws/serviceFullName "Amazon SageMaker Service"}
-        com.cognitect.aws/sagemaker-a2i-runtime {:mvn/version "796.2.657.0", :aws/serviceFullName "Amazon Augmented AI Runtime"}
-        com.cognitect.aws/sagemaker-edge {:mvn/version "810.2.817.0", :aws/serviceFullName "Amazon Sagemaker Edge Manager"}
-        com.cognitect.aws/sagemaker-featurestore-runtime {:mvn/version "810.2.801.0", :aws/serviceFullName "Amazon SageMaker Feature Store Runtime"}
-        com.cognitect.aws/savingsplans {:mvn/version "809.2.784.0", :aws/serviceFullName "AWS Savings Plans"}
-        com.cognitect.aws/schemas {:mvn/version "809.2.784.0", :aws/serviceFullName "Schemas"}
-        com.cognitect.aws/sdb {:mvn/version "770.2.568.0", :aws/serviceFullName "Amazon SimpleDB"}
-        com.cognitect.aws/secretsmanager {:mvn/version "802.2.713.0", :aws/serviceFullName "AWS Secrets Manager"}
-        com.cognitect.aws/securityhub {:mvn/version "810.2.817.0", :aws/serviceFullName "AWS SecurityHub"}
-        com.cognitect.aws/serverlessrepo {:mvn/version "794.2.637.0", :aws/serviceFullName "AWSServerlessApplicationRepository"}
-        com.cognitect.aws/service-quotas {:mvn/version "810.2.817.0", :aws/serviceFullName "Service Quotas"}
-        com.cognitect.aws/servicecatalog {:mvn/version "811.2.824.0", :aws/serviceFullName "AWS Service Catalog"}
-        com.cognitect.aws/servicediscovery {:mvn/version "809.2.784.0", :aws/serviceFullName "AWS Cloud Map"}
-        com.cognitect.aws/sesv2 {:mvn/version "809.2.784.0", :aws/serviceFullName "Amazon Simple Email Service"}
-        com.cognitect.aws/shield {:mvn/version "809.2.797.0", :aws/serviceFullName "AWS Shield"}
-        com.cognitect.aws/signer {:mvn/version "810.2.801.0", :aws/serviceFullName "AWS Signer"}
-        com.cognitect.aws/sms {:mvn/version "807.2.729.0", :aws/serviceFullName "AWS Server Migration Service"}
-        com.cognitect.aws/snowball {:mvn/version "809.2.784.0", :aws/serviceFullName "Amazon Import/Export Snowball"}
-        com.cognitect.aws/sns {:mvn/version "809.2.797.0", :aws/serviceFullName "Amazon Simple Notification Service"}
-        com.cognitect.aws/sqs {:mvn/version "810.2.817.0", :aws/serviceFullName "Amazon Simple Queue Service"}
-        com.cognitect.aws/ssm {:mvn/version "810.2.817.0", :aws/serviceFullName "Amazon Simple Systems Manager (SSM)"}
-        com.cognitect.aws/sso {:mvn/version "770.2.568.0", :aws/serviceFullName "AWS Single Sign-On"}
-        com.cognitect.aws/sso-admin {:mvn/version "810.2.801.0", :aws/serviceFullName "AWS Single Sign-On Admin"}
-        com.cognitect.aws/sso-oidc {:mvn/version "770.2.568.0", :aws/serviceFullName "AWS SSO OIDC"}
-        com.cognitect.aws/states {:mvn/version "810.2.801.0", :aws/serviceFullName "AWS Step Functions"}
-        com.cognitect.aws/storagegateway {:mvn/version "809.2.797.0", :aws/serviceFullName "AWS Storage Gateway"}
-        com.cognitect.aws/streams-dynamodb {:mvn/version "809.2.784.0", :aws/serviceFullName "Amazon DynamoDB Streams"}
-        com.cognitect.aws/sts {:mvn/version "809.2.784.0", :aws/serviceFullName "AWS Security Token Service"}
-        com.cognitect.aws/support {:mvn/version "801.2.700.0", :aws/serviceFullName "AWS Support"}
-        com.cognitect.aws/swf {:mvn/version "770.2.568.0", :aws/serviceFullName "Amazon Simple Workflow Service"}
-        com.cognitect.aws/synthetics {:mvn/version "809.2.797.0", :aws/serviceFullName "Synthetics"}
-        com.cognitect.aws/textract {:mvn/version "809.2.797.0", :aws/serviceFullName "Amazon Textract"}
-        com.cognitect.aws/timestream-query {:mvn/version "810.2.801.0", :aws/serviceFullName "Amazon Timestream Query"}
-        com.cognitect.aws/timestream-write {:mvn/version "810.2.801.0", :aws/serviceFullName "Amazon Timestream Write"}
-        com.cognitect.aws/transcribe {:mvn/version "809.2.784.0", :aws/serviceFullName "Amazon Transcribe Service"}
-        com.cognitect.aws/transfer {:mvn/version "811.2.824.0", :aws/serviceFullName "AWS Transfer Family"}
-        com.cognitect.aws/translate {:mvn/version "810.2.801.0", :aws/serviceFullName "Amazon Translate"}
-        com.cognitect.aws/waf {:mvn/version "796.2.666.0", :aws/serviceFullName "AWS WAF"}
-        com.cognitect.aws/waf-regional {:mvn/version "796.2.666.0", :aws/serviceFullName "AWS WAF Regional"}
-        com.cognitect.aws/wafv2 {:mvn/version "809.2.784.0", :aws/serviceFullName "AWS WAFV2"}
-        com.cognitect.aws/wellarchitected {:mvn/version "810.2.817.0", :aws/serviceFullName "AWS Well-Architected Tool"}
-        com.cognitect.aws/workdocs {:mvn/version "793.2.629.0", :aws/serviceFullName "Amazon WorkDocs"}
-        com.cognitect.aws/worklink {:mvn/version "801.2.687.0", :aws/serviceFullName "Amazon WorkLink"}
-        com.cognitect.aws/workmail {:mvn/version "809.2.784.0", :aws/serviceFullName "Amazon WorkMail"}
-        com.cognitect.aws/workmailmessageflow {:mvn/version "770.2.568.0", :aws/serviceFullName "Amazon WorkMail Message Flow"}
-        com.cognitect.aws/workspaces {:mvn/version "810.2.805.0", :aws/serviceFullName "Amazon WorkSpaces"}
-        com.cognitect.aws/xray {:mvn/version "809.2.797.0", :aws/serviceFullName "AWS X-Ray"}
-        }
- }
+        com.cognitect.aws/AWS242AppRegistry               {:mvn/version "810.2.817.0" :aws/serviceFullName "AWS Service Catalog App Registry"}
+        com.cognitect.aws/AWSMigrationHub                 {:mvn/version "796.2.657.0" :aws/serviceFullName "AWS Migration Hub"}
+        com.cognitect.aws/accessanalyzer                  {:mvn/version "809.2.784.0" :aws/serviceFullName "Access Analyzer"}
+        com.cognitect.aws/acm                             {:mvn/version "809.2.784.0" :aws/serviceFullName "AWS Certificate Manager"}
+        com.cognitect.aws/acm-pca                         {:mvn/version "811.2.824.0" :aws/serviceFullName "AWS Certificate Manager Private Certificate Authority"}
+        com.cognitect.aws/alexaforbusiness                {:mvn/version "802.2.713.0" :aws/serviceFullName "Alexa For Business"}
+        com.cognitect.aws/amp                             {:mvn/version "810.2.817.0" :aws/serviceFullName "Amazon Prometheus Service"}
+        com.cognitect.aws/amplify                         {:mvn/version "809.2.797.0" :aws/serviceFullName "AWS Amplify"}
+        com.cognitect.aws/amplifybackend                  {:mvn/version "810.2.805.0" :aws/serviceFullName "AmplifyBackend"}
+        com.cognitect.aws/api                             {:mvn/version "0.8.498" :aws/serviceFullName ""}
+        com.cognitect.aws/apigateway                      {:mvn/version "810.2.817.0" :aws/serviceFullName "Amazon API Gateway"}
+        com.cognitect.aws/apigatewaymanagementapi         {:mvn/version "770.2.568.0" :aws/serviceFullName "AmazonApiGatewayManagementApi"}
+        com.cognitect.aws/apigatewayv2                    {:mvn/version "811.2.824.0" :aws/serviceFullName "AmazonApiGatewayV2"}
+        com.cognitect.aws/appconfig                       {:mvn/version "801.2.697.0" :aws/serviceFullName "Amazon AppConfig"}
+        com.cognitect.aws/appflow                         {:mvn/version "810.2.801.0" :aws/serviceFullName "Amazon Appflow"}
+        com.cognitect.aws/appintegrations                 {:mvn/version "810.2.801.0" :aws/serviceFullName "Amazon AppIntegrations Service"}
+        com.cognitect.aws/application-autoscaling         {:mvn/version "811.2.824.0" :aws/serviceFullName "Application Auto Scaling"}
+        com.cognitect.aws/application-insights            {:mvn/version "810.2.801.0" :aws/serviceFullName "Amazon CloudWatch Application Insights"}
+        com.cognitect.aws/appmesh                         {:mvn/version "809.2.797.0" :aws/serviceFullName "AWS App Mesh"}
+        com.cognitect.aws/appstream                       {:mvn/version "809.2.734.0" :aws/serviceFullName "Amazon AppStream"}
+        com.cognitect.aws/appsync                         {:mvn/version "809.2.784.0" :aws/serviceFullName "AWS AppSync"}
+        com.cognitect.aws/athena                          {:mvn/version "801.2.687.0" :aws/serviceFullName "Amazon Athena"}
+        com.cognitect.aws/auditmanager                    {:mvn/version "810.2.817.0" :aws/serviceFullName "AWS Audit Manager"}
+        com.cognitect.aws/autoscaling                     {:mvn/version "811.2.824.0" :aws/serviceFullName "Auto Scaling"}
+        com.cognitect.aws/autoscaling-plans               {:mvn/version "811.2.824.0" :aws/serviceFullName "AWS Auto Scaling Plans"}
+        com.cognitect.aws/backup                          {:mvn/version "809.2.797.0" :aws/serviceFullName "AWS Backup"}
+        com.cognitect.aws/batch                           {:mvn/version "810.2.817.0" :aws/serviceFullName "AWS Batch"}
+        com.cognitect.aws/braket                          {:mvn/version "810.2.797.0" :aws/serviceFullName "Braket"}
+        com.cognitect.aws/budgets                         {:mvn/version "809.2.784.0" :aws/serviceFullName "AWS Budgets"}
+        com.cognitect.aws/ce                              {:mvn/version "811.2.824.0" :aws/serviceFullName "AWS Cost Explorer Service"}
+        com.cognitect.aws/chime                           {:mvn/version "809.2.797.0" :aws/serviceFullName "Amazon Chime"}
+        com.cognitect.aws/cloud9                          {:mvn/version "809.2.734.0" :aws/serviceFullName "AWS Cloud9"}
+        com.cognitect.aws/clouddirectory                  {:mvn/version "770.2.568.0" :aws/serviceFullName "Amazon CloudDirectory"}
+        com.cognitect.aws/cloudformation                  {:mvn/version "810.2.801.0" :aws/serviceFullName "AWS CloudFormation"}
+        com.cognitect.aws/cloudfront                      {:mvn/version "811.2.824.0" :aws/serviceFullName "Amazon CloudFront"}
+        com.cognitect.aws/cloudhsm                        {:mvn/version "770.2.568.0" :aws/serviceFullName "Amazon CloudHSM"}
+        com.cognitect.aws/cloudhsmv2                      {:mvn/version "809.2.797.0" :aws/serviceFullName "AWS CloudHSM V2"}
+        com.cognitect.aws/cloudsearch                     {:mvn/version "811.2.824.0" :aws/serviceFullName "Amazon CloudSearch"}
+        com.cognitect.aws/cloudsearchdomain               {:mvn/version "770.2.568.0" :aws/serviceFullName "Amazon CloudSearch Domain"}
+        com.cognitect.aws/cloudtrail                      {:mvn/version "810.2.817.0" :aws/serviceFullName "AWS CloudTrail"}
+        com.cognitect.aws/codeartifact                    {:mvn/version "810.2.801.0" :aws/serviceFullName "CodeArtifact"}
+        com.cognitect.aws/codebuild                       {:mvn/version "810.2.802.0" :aws/serviceFullName "AWS CodeBuild"}
+        com.cognitect.aws/codecommit                      {:mvn/version "801.2.704.0" :aws/serviceFullName "AWS CodeCommit"}
+        com.cognitect.aws/codedeploy                      {:mvn/version "799.2.681.0" :aws/serviceFullName "AWS CodeDeploy"}
+        com.cognitect.aws/codeguru-reviewer               {:mvn/version "809.2.797.0" :aws/serviceFullName "Amazon CodeGuru Reviewer"}
+        com.cognitect.aws/codeguruprofiler                {:mvn/version "803.2.717.0" :aws/serviceFullName "Amazon CodeGuru Profiler"}
+        com.cognitect.aws/codepipeline                    {:mvn/version "811.2.824.0" :aws/serviceFullName "AWS CodePipeline"}
+        com.cognitect.aws/codestar                        {:mvn/version "770.2.568.0" :aws/serviceFullName "AWS CodeStar"}
+        com.cognitect.aws/codestar-connections            {:mvn/version "810.2.801.0" :aws/serviceFullName "AWS CodeStar connections"}
+        com.cognitect.aws/codestar-notifications          {:mvn/version "770.2.568.0" :aws/serviceFullName "AWS CodeStar Notifications"}
+        com.cognitect.aws/cognito-identity                {:mvn/version "809.2.797.0" :aws/serviceFullName "Amazon Cognito Identity"}
+        com.cognitect.aws/cognito-idp                     {:mvn/version "810.2.801.0" :aws/serviceFullName "Amazon Cognito Identity Provider"}
+        com.cognitect.aws/cognito-sync                    {:mvn/version "770.2.568.0" :aws/serviceFullName "Amazon Cognito Sync"}
+        com.cognitect.aws/comprehend                      {:mvn/version "810.2.801.0" :aws/serviceFullName "Amazon Comprehend"}
+        com.cognitect.aws/comprehendmedical               {:mvn/version "801.2.708.0" :aws/serviceFullName "AWS Comprehend Medical"}
+        com.cognitect.aws/compute-optimizer               {:mvn/version "810.2.817.0" :aws/serviceFullName "AWS Compute Optimizer"}
+        com.cognitect.aws/config                          {:mvn/version "810.2.817.0" :aws/serviceFullName "AWS Config"}
+        com.cognitect.aws/connect                         {:mvn/version "810.2.817.0" :aws/serviceFullName "Amazon Connect Service"}
+        com.cognitect.aws/connect-contact-lens            {:mvn/version "810.2.801.0" :aws/serviceFullName "Amazon Connect Contact Lens"}
+        com.cognitect.aws/connectparticipant              {:mvn/version "810.2.817.0" :aws/serviceFullName "Amazon Connect Participant Service"}
+        com.cognitect.aws/cur                             {:mvn/version "809.2.784.0" :aws/serviceFullName "AWS Cost and Usage Report Service"}
+        com.cognitect.aws/customer-profiles               {:mvn/version "810.2.802.0" :aws/serviceFullName "Amazon Connect Customer Profiles"}
+        com.cognitect.aws/databrew                        {:mvn/version "810.2.797.0" :aws/serviceFullName "AWS Glue DataBrew"}
+        com.cognitect.aws/dataexchange                    {:mvn/version "801.2.698.0" :aws/serviceFullName "AWS Data Exchange"}
+        com.cognitect.aws/datapipeline                    {:mvn/version "770.2.568.0" :aws/serviceFullName "AWS Data Pipeline"}
+        com.cognitect.aws/datasync                        {:mvn/version "809.2.797.0" :aws/serviceFullName "AWS DataSync"}
+        com.cognitect.aws/dax                             {:mvn/version "770.2.568.0" :aws/serviceFullName "Amazon DynamoDB Accelerator (DAX)"}
+        com.cognitect.aws/detective                       {:mvn/version "796.2.650.0" :aws/serviceFullName "Amazon Detective"}
+        com.cognitect.aws/devicefarm                      {:mvn/version "784.2.595.0" :aws/serviceFullName "AWS Device Farm"}
+        com.cognitect.aws/devices                         {:mvn/version "770.2.568.0" :aws/serviceFullName "AWS IoT 1-Click Devices Service"}
+        com.cognitect.aws/devops-guru                     {:mvn/version "811.2.824.0" :aws/serviceFullName "Amazon DevOps Guru"}
+        com.cognitect.aws/directconnect                   {:mvn/version "809.2.784.0" :aws/serviceFullName "AWS Direct Connect"}
+        com.cognitect.aws/discovery                       {:mvn/version "788.2.608.0" :aws/serviceFullName "AWS Application Discovery Service"}
+        com.cognitect.aws/dlm                             {:mvn/version "810.2.817.0" :aws/serviceFullName "Amazon Data Lifecycle Manager"}
+        com.cognitect.aws/dms                             {:mvn/version "810.2.817.0" :aws/serviceFullName "AWS Database Migration Service"}
+        com.cognitect.aws/docdb                           {:mvn/version "809.2.784.0" :aws/serviceFullName "Amazon DocumentDB with MongoDB compatibility"}
+        com.cognitect.aws/ds                              {:mvn/version "810.2.805.0" :aws/serviceFullName "AWS Directory Service"}
+        com.cognitect.aws/dynamodb                        {:mvn/version "810.2.801.0" :aws/serviceFullName "Amazon DynamoDB"}
+        com.cognitect.aws/ebs                             {:mvn/version "809.2.784.0" :aws/serviceFullName "Amazon Elastic Block Store"}
+        com.cognitect.aws/ec2                             {:mvn/version "810.2.817.0" :aws/serviceFullName "Amazon Elastic Compute Cloud"}
+        com.cognitect.aws/ec2-instance-connect            {:mvn/version "770.2.568.0" :aws/serviceFullName "AWS EC2 Instance Connect"}
+        com.cognitect.aws/ecr                             {:mvn/version "810.2.817.0" :aws/serviceFullName "Amazon EC2 Container Registry"}
+        com.cognitect.aws/ecr-public                      {:mvn/version "810.2.801.0" :aws/serviceFullName "Amazon Elastic Container Registry Public"}
+        com.cognitect.aws/ecs                             {:mvn/version "810.2.801.0" :aws/serviceFullName "Amazon EC2 Container Service"}
+        com.cognitect.aws/eks                             {:mvn/version "810.2.801.0" :aws/serviceFullName "Amazon Elastic Kubernetes Service"}
+        com.cognitect.aws/elastic-inference               {:mvn/version "796.2.663.0" :aws/serviceFullName "Amazon Elastic  Inference"}
+        com.cognitect.aws/elasticache                     {:mvn/version "811.2.824.0" :aws/serviceFullName "Amazon ElastiCache"}
+        com.cognitect.aws/elasticbeanstalk                {:mvn/version "810.2.801.0" :aws/serviceFullName "AWS Elastic Beanstalk"}
+        com.cognitect.aws/elasticfilesystem               {:mvn/version "802.2.711.0" :aws/serviceFullName "Amazon Elastic File System"}
+        com.cognitect.aws/elasticloadbalancing            {:mvn/version "809.2.784.0" :aws/serviceFullName "Elastic Load Balancing"}
+        com.cognitect.aws/elasticloadbalancingv2          {:mvn/version "809.2.797.0" :aws/serviceFullName "Elastic Load Balancing"}
+        com.cognitect.aws/elasticmapreduce                {:mvn/version "810.2.801.0" :aws/serviceFullName "Amazon Elastic MapReduce"}
+        com.cognitect.aws/elastictranscoder               {:mvn/version "770.2.568.0" :aws/serviceFullName "Amazon Elastic Transcoder"}
+        com.cognitect.aws/email                           {:mvn/version "770.2.568.0" :aws/serviceFullName "Amazon Simple Email Service"}
+        com.cognitect.aws/emr-containers                  {:mvn/version "810.2.817.0" :aws/serviceFullName "Amazon EMR Containers"}
+        com.cognitect.aws/endpoints                       {:mvn/version "1.1.11.934" :aws/serviceFullName ""}
+        com.cognitect.aws/entitlement-marketplace         {:mvn/version "770.2.568.0" :aws/serviceFullName "AWS Marketplace Entitlement Service"}
+        com.cognitect.aws/es                              {:mvn/version "809.2.797.0" :aws/serviceFullName "Amazon Elasticsearch Service"}
+        com.cognitect.aws/eventbridge                     {:mvn/version "809.2.797.0" :aws/serviceFullName "Amazon EventBridge"}
+        com.cognitect.aws/events                          {:mvn/version "809.2.797.0" :aws/serviceFullName "Amazon CloudWatch Events"}
+        com.cognitect.aws/firehose                        {:mvn/version "807.2.729.0" :aws/serviceFullName "Amazon Kinesis Firehose"}
+        com.cognitect.aws/fms                             {:mvn/version "809.2.797.0" :aws/serviceFullName "Firewall Management Service"}
+        com.cognitect.aws/forecast                        {:mvn/version "810.2.817.0" :aws/serviceFullName "Amazon Forecast Service"}
+        com.cognitect.aws/forecastquery                   {:mvn/version "789.2.612.0" :aws/serviceFullName "Amazon Forecast Query Service"}
+        com.cognitect.aws/frauddetector                   {:mvn/version "809.2.797.0" :aws/serviceFullName "Amazon Fraud Detector"}
+        com.cognitect.aws/fsx                             {:mvn/version "810.2.801.0" :aws/serviceFullName "Amazon FSx"}
+        com.cognitect.aws/gamelift                        {:mvn/version "810.2.801.0" :aws/serviceFullName "Amazon GameLift"}
+        com.cognitect.aws/glacier                         {:mvn/version "770.2.568.0" :aws/serviceFullName "Amazon Glacier"}
+        com.cognitect.aws/globalaccelerator               {:mvn/version "810.2.817.0" :aws/serviceFullName "AWS Global Accelerator"}
+        com.cognitect.aws/glue                            {:mvn/version "810.2.817.0" :aws/serviceFullName "AWS Glue"}
+        com.cognitect.aws/greengrass                      {:mvn/version "809.2.784.0" :aws/serviceFullName "AWS Greengrass"}
+        com.cognitect.aws/greengrassv2                    {:mvn/version "810.2.817.0" :aws/serviceFullName "AWS IoT Greengrass V2"}
+        com.cognitect.aws/groundstation                   {:mvn/version "809.2.784.0" :aws/serviceFullName "AWS Ground Station"}
+        com.cognitect.aws/guardduty                       {:mvn/version "810.2.817.0" :aws/serviceFullName "Amazon GuardDuty"}
+        com.cognitect.aws/health                          {:mvn/version "807.2.729.0" :aws/serviceFullName "AWS Health APIs and Notifications"}
+        com.cognitect.aws/healthlake                      {:mvn/version "811.2.824.0" :aws/serviceFullName "Amazon HealthLake"}
+        com.cognitect.aws/honeycode                       {:mvn/version "810.2.801.0" :aws/serviceFullName "Amazon Honeycode"}
+        com.cognitect.aws/iam                             {:mvn/version "801.2.704.0" :aws/serviceFullName "AWS Identity and Access Management"}
+        com.cognitect.aws/identitystore                   {:mvn/version "810.2.797.0" :aws/serviceFullName "AWS SSO Identity Store"}
+        com.cognitect.aws/imagebuilder                    {:mvn/version "810.2.817.0" :aws/serviceFullName "EC2 Image Builder"}
+        com.cognitect.aws/importexport                    {:mvn/version "770.2.568.0" :aws/serviceFullName "AWS Import/Export"}
+        com.cognitect.aws/inspector                       {:mvn/version "770.2.568.0" :aws/serviceFullName "Amazon Inspector"}
+        com.cognitect.aws/iot                             {:mvn/version "810.2.817.0" :aws/serviceFullName "AWS IoT"}
+        com.cognitect.aws/iot-data                        {:mvn/version "801.2.695.0" :aws/serviceFullName "AWS IoT Data Plane"}
+        com.cognitect.aws/iot-jobs-data                   {:mvn/version "770.2.568.0" :aws/serviceFullName "AWS IoT Jobs Data Plane"}
+        com.cognitect.aws/iot1click-projects              {:mvn/version "770.2.568.0" :aws/serviceFullName "AWS IoT 1-Click Projects Service"}
+        com.cognitect.aws/iotanalytics                    {:mvn/version "810.2.817.0" :aws/serviceFullName "AWS IoT Analytics"}
+        com.cognitect.aws/iotdeviceadvisor                {:mvn/version "810.2.817.0" :aws/serviceFullName "AWS IoT Core Device Advisor"}
+        com.cognitect.aws/iotevents                       {:mvn/version "796.2.667.0" :aws/serviceFullName "AWS IoT Events"}
+        com.cognitect.aws/iotevents-data                  {:mvn/version "770.2.568.0" :aws/serviceFullName "AWS IoT Events Data"}
+        com.cognitect.aws/iotfleethub                     {:mvn/version "810.2.817.0" :aws/serviceFullName "AWS IoT Fleet Hub"}
+        com.cognitect.aws/iotsecuretunneling              {:mvn/version "809.2.797.0" :aws/serviceFullName "AWS IoT Secure Tunneling"}
+        com.cognitect.aws/iotsitewise                     {:mvn/version "810.2.817.0" :aws/serviceFullName "AWS IoT SiteWise"}
+        com.cognitect.aws/iotthingsgraph                  {:mvn/version "770.2.568.0" :aws/serviceFullName "AWS IoT Things Graph"}
+        com.cognitect.aws/iotwireless                     {:mvn/version "810.2.817.0" :aws/serviceFullName "AWS IoT Wireless"}
+        com.cognitect.aws/ivs                             {:mvn/version "809.2.784.0" :aws/serviceFullName "Amazon Interactive Video Service"}
+        com.cognitect.aws/kafka                           {:mvn/version "810.2.805.0" :aws/serviceFullName "Managed Streaming for Kafka"}
+        com.cognitect.aws/kendra                          {:mvn/version "810.2.817.0" :aws/serviceFullName "AWSKendraFrontendService"}
+        com.cognitect.aws/kinesis                         {:mvn/version "809.2.784.0" :aws/serviceFullName "Amazon Kinesis"}
+        com.cognitect.aws/kinesis-video-archived-media    {:mvn/version "796.2.665.0" :aws/serviceFullName "Amazon Kinesis Video Streams Archived Media"}
+        com.cognitect.aws/kinesis-video-media             {:mvn/version "770.2.568.0" :aws/serviceFullName "Amazon Kinesis Video Streams Media"}
+        com.cognitect.aws/kinesis-video-signaling         {:mvn/version "781.2.585.0" :aws/serviceFullName "Amazon Kinesis Video Signaling Channels"}
+        com.cognitect.aws/kinesisanalytics                {:mvn/version "770.2.568.0" :aws/serviceFullName "Amazon Kinesis Analytics"}
+        com.cognitect.aws/kinesisanalyticsv2              {:mvn/version "809.2.797.0" :aws/serviceFullName "Amazon Kinesis Analytics"}
+        com.cognitect.aws/kinesisvideo                    {:mvn/version "796.2.665.0" :aws/serviceFullName "Amazon Kinesis Video Streams"}
+        com.cognitect.aws/kms                             {:mvn/version "810.2.817.0" :aws/serviceFullName "AWS Key Management Service"}
+        com.cognitect.aws/lakeformation                   {:mvn/version "809.2.784.0" :aws/serviceFullName "AWS Lake Formation"}
+        com.cognitect.aws/lambda                          {:mvn/version "810.2.817.0" :aws/serviceFullName "AWS Lambda"}
+        com.cognitect.aws/lex-models                      {:mvn/version "810.2.801.0" :aws/serviceFullName "Amazon Lex Model Building Service"}
+        com.cognitect.aws/license-manager                 {:mvn/version "810.2.805.0" :aws/serviceFullName "AWS License Manager"}
+        com.cognitect.aws/lightsail                       {:mvn/version "809.2.797.0" :aws/serviceFullName "Amazon Lightsail"}
+        com.cognitect.aws/location                        {:mvn/version "810.2.817.0" :aws/serviceFullName "Amazon Location Service"}
+        com.cognitect.aws/logs                            {:mvn/version "809.2.784.0" :aws/serviceFullName "Amazon CloudWatch Logs"}
+        com.cognitect.aws/lookoutvision                   {:mvn/version "810.2.801.0" :aws/serviceFullName "Amazon Lookout for Vision"}
+        com.cognitect.aws/machinelearning                 {:mvn/version "770.2.568.0" :aws/serviceFullName "Amazon Machine Learning"}
+        com.cognitect.aws/macie                           {:mvn/version "801.2.684.0" :aws/serviceFullName "Amazon Macie"}
+        com.cognitect.aws/macie2                          {:mvn/version "811.2.824.0" :aws/serviceFullName "Amazon Macie 2"}
+        com.cognitect.aws/managedblockchain               {:mvn/version "810.2.817.0" :aws/serviceFullName "Amazon Managed Blockchain"}
+        com.cognitect.aws/marketplace-catalog             {:mvn/version "809.2.784.0" :aws/serviceFullName "AWS Marketplace Catalog Service"}
+        com.cognitect.aws/marketplacecommerceanalytics    {:mvn/version "809.2.784.0" :aws/serviceFullName "AWS Marketplace Commerce Analytics"}
+        com.cognitect.aws/mediaconnect                    {:mvn/version "809.2.784.0" :aws/serviceFullName "AWS MediaConnect"}
+        com.cognitect.aws/mediaconvert                    {:mvn/version "811.2.824.0" :aws/serviceFullName "AWS Elemental MediaConvert"}
+        com.cognitect.aws/medialive                       {:mvn/version "810.2.805.0" :aws/serviceFullName "AWS Elemental MediaLive"}
+        com.cognitect.aws/mediapackage                    {:mvn/version "809.2.784.0" :aws/serviceFullName "AWS Elemental MediaPackage"}
+        com.cognitect.aws/mediapackage-vod                {:mvn/version "801.2.690.0" :aws/serviceFullName "AWS Elemental MediaPackage VOD"}
+        com.cognitect.aws/mediastore                      {:mvn/version "796.2.650.0" :aws/serviceFullName "AWS Elemental MediaStore"}
+        com.cognitect.aws/mediastore-data                 {:mvn/version "770.2.568.0" :aws/serviceFullName "AWS Elemental MediaStore Data Plane"}
+        com.cognitect.aws/mediatailor                     {:mvn/version "809.2.784.0" :aws/serviceFullName "AWS MediaTailor"}
+        com.cognitect.aws/meteringmarketplace             {:mvn/version "809.2.797.0" :aws/serviceFullName "AWSMarketplace Metering"}
+        com.cognitect.aws/migrationhub-config             {:mvn/version "796.2.656.0" :aws/serviceFullName "AWS Migration Hub Config"}
+        com.cognitect.aws/mobile                          {:mvn/version "770.2.568.0" :aws/serviceFullName "AWS Mobile"}
+        com.cognitect.aws/mobileanalytics                 {:mvn/version "770.2.568.0" :aws/serviceFullName "Amazon Mobile Analytics"}
+        com.cognitect.aws/monitoring                      {:mvn/version "810.2.817.0" :aws/serviceFullName "Amazon CloudWatch"}
+        com.cognitect.aws/mq                              {:mvn/version "809.2.797.0" :aws/serviceFullName "AmazonMQ"}
+        com.cognitect.aws/mturk-requester                 {:mvn/version "770.2.568.0" :aws/serviceFullName "Amazon Mechanical Turk"}
+        com.cognitect.aws/mwaa                            {:mvn/version "810.2.801.0" :aws/serviceFullName "AmazonMWAA"}
+        com.cognitect.aws/neptune                         {:mvn/version "809.2.784.0" :aws/serviceFullName "Amazon Neptune"}
+        com.cognitect.aws/network-firewall                {:mvn/version "810.2.797.0" :aws/serviceFullName "AWS Network Firewall"}
+        com.cognitect.aws/networkmanager                  {:mvn/version "810.2.817.0" :aws/serviceFullName "AWS Network Manager"}
+        com.cognitect.aws/opsworks                        {:mvn/version "770.2.568.0" :aws/serviceFullName "AWS OpsWorks"}
+        com.cognitect.aws/opsworkscm                      {:mvn/version "801.2.701.0" :aws/serviceFullName "AWS OpsWorks CM"}
+        com.cognitect.aws/organizations                   {:mvn/version "809.2.784.0" :aws/serviceFullName "AWS Organizations"}
+        com.cognitect.aws/outposts                        {:mvn/version "810.2.817.0" :aws/serviceFullName "AWS Outposts"}
+        com.cognitect.aws/personalize                     {:mvn/version "807.2.729.0" :aws/serviceFullName "Amazon Personalize"}
+        com.cognitect.aws/personalize-events              {:mvn/version "809.2.784.0" :aws/serviceFullName "Amazon Personalize Events"}
+        com.cognitect.aws/personalize-runtime             {:mvn/version "810.2.817.0" :aws/serviceFullName "Amazon Personalize Runtime"}
+        com.cognitect.aws/pi                              {:mvn/version "810.2.817.0" :aws/serviceFullName "AWS Performance Insights"}
+        com.cognitect.aws/pinpoint                        {:mvn/version "809.2.784.0" :aws/serviceFullName "Amazon Pinpoint"}
+        com.cognitect.aws/pinpoint-email                  {:mvn/version "770.2.568.0" :aws/serviceFullName "Amazon Pinpoint Email Service"}
+        com.cognitect.aws/pinpoint-sms-voice              {:mvn/version "770.2.568.0" :aws/serviceFullName "Amazon Pinpoint SMS and Voice Service"}
+        com.cognitect.aws/polly                           {:mvn/version "809.2.797.0" :aws/serviceFullName "Amazon Polly"}
+        com.cognitect.aws/pricing                         {:mvn/version "770.2.568.0" :aws/serviceFullName "AWS Price List Service"}
+        com.cognitect.aws/qldb                            {:mvn/version "801.2.698.0" :aws/serviceFullName "Amazon QLDB"}
+        com.cognitect.aws/qldb-session                    {:mvn/version "810.2.817.0" :aws/serviceFullName "Amazon QLDB Session"}
+        com.cognitect.aws/quicksight                      {:mvn/version "810.2.817.0" :aws/serviceFullName "Amazon QuickSight"}
+        com.cognitect.aws/ram                             {:mvn/version "796.2.662.0" :aws/serviceFullName "AWS Resource Access Manager"}
+        com.cognitect.aws/rds                             {:mvn/version "810.2.817.0" :aws/serviceFullName "Amazon Relational Database Service"}
+        com.cognitect.aws/rds-data                        {:mvn/version "795.2.645.0" :aws/serviceFullName "AWS RDS DataService"}
+        com.cognitect.aws/redshift                        {:mvn/version "810.2.817.0" :aws/serviceFullName "Amazon Redshift"}
+        com.cognitect.aws/redshift-data                   {:mvn/version "810.2.801.0" :aws/serviceFullName "Redshift Data API Service"}
+        com.cognitect.aws/rekognition                     {:mvn/version "809.2.784.0" :aws/serviceFullName "Amazon Rekognition"}
+        com.cognitect.aws/resource-groups                 {:mvn/version "810.2.817.0" :aws/serviceFullName "AWS Resource Groups"}
+        com.cognitect.aws/resourcegroupstaggingapi        {:mvn/version "809.2.784.0" :aws/serviceFullName "AWS Resource Groups Tagging API"}
+        com.cognitect.aws/robomaker                       {:mvn/version "809.2.797.0" :aws/serviceFullName "AWS RoboMaker"}
+        com.cognitect.aws/route53                         {:mvn/version "810.2.817.0" :aws/serviceFullName "Amazon Route 53"}
+        com.cognitect.aws/route53domains                  {:mvn/version "796.2.660.0" :aws/serviceFullName "Amazon Route 53 Domains"}
+        com.cognitect.aws/route53resolver                 {:mvn/version "810.2.817.0" :aws/serviceFullName "Amazon Route 53 Resolver"}
+        com.cognitect.aws/runtime-lex                     {:mvn/version "809.2.797.0" :aws/serviceFullName "Amazon Lex Runtime Service"}
+        com.cognitect.aws/runtime-sagemaker               {:mvn/version "810.2.817.0" :aws/serviceFullName "Amazon SageMaker Runtime"}
+        com.cognitect.aws/s3                              {:mvn/version "810.2.817.0" :aws/serviceFullName "Amazon Simple Storage Service"}
+        com.cognitect.aws/s3control                       {:mvn/version "809.2.797.0" :aws/serviceFullName "AWS S3 Control"}
+        com.cognitect.aws/s3outposts                      {:mvn/version "810.2.797.0" :aws/serviceFullName "Amazon S3 on Outposts"}
+        com.cognitect.aws/sagemaker                       {:mvn/version "810.2.817.0" :aws/serviceFullName "Amazon SageMaker Service"}
+        com.cognitect.aws/sagemaker-a2i-runtime           {:mvn/version "796.2.657.0" :aws/serviceFullName "Amazon Augmented AI Runtime"}
+        com.cognitect.aws/sagemaker-edge                  {:mvn/version "810.2.817.0" :aws/serviceFullName "Amazon Sagemaker Edge Manager"}
+        com.cognitect.aws/sagemaker-featurestore-runtime   {:mvn/version "810.2.801.0" :aws/serviceFullName "Amazon SageMaker Feature Store Runtime"}
+        com.cognitect.aws/savingsplans                    {:mvn/version "809.2.784.0" :aws/serviceFullName "AWS Savings Plans"}
+        com.cognitect.aws/schemas                         {:mvn/version "809.2.784.0" :aws/serviceFullName "Schemas"}
+        com.cognitect.aws/sdb                             {:mvn/version "770.2.568.0" :aws/serviceFullName "Amazon SimpleDB"}
+        com.cognitect.aws/secretsmanager                  {:mvn/version "802.2.713.0" :aws/serviceFullName "AWS Secrets Manager"}
+        com.cognitect.aws/securityhub                     {:mvn/version "810.2.817.0" :aws/serviceFullName "AWS SecurityHub"}
+        com.cognitect.aws/serverlessrepo                  {:mvn/version "794.2.637.0" :aws/serviceFullName "AWSServerlessApplicationRepository"}
+        com.cognitect.aws/service-quotas                  {:mvn/version "810.2.817.0" :aws/serviceFullName "Service Quotas"}
+        com.cognitect.aws/servicecatalog                  {:mvn/version "811.2.824.0" :aws/serviceFullName "AWS Service Catalog"}
+        com.cognitect.aws/servicediscovery                {:mvn/version "809.2.784.0" :aws/serviceFullName "AWS Cloud Map"}
+        com.cognitect.aws/sesv2                           {:mvn/version "809.2.784.0" :aws/serviceFullName "Amazon Simple Email Service"}
+        com.cognitect.aws/shield                          {:mvn/version "809.2.797.0" :aws/serviceFullName "AWS Shield"}
+        com.cognitect.aws/signer                          {:mvn/version "810.2.801.0" :aws/serviceFullName "AWS Signer"}
+        com.cognitect.aws/sms                             {:mvn/version "807.2.729.0" :aws/serviceFullName "AWS Server Migration Service"}
+        com.cognitect.aws/snowball                        {:mvn/version "809.2.784.0" :aws/serviceFullName "Amazon Import/Export Snowball"}
+        com.cognitect.aws/sns                             {:mvn/version "809.2.797.0" :aws/serviceFullName "Amazon Simple Notification Service"}
+        com.cognitect.aws/sqs                             {:mvn/version "810.2.817.0" :aws/serviceFullName "Amazon Simple Queue Service"}
+        com.cognitect.aws/ssm                             {:mvn/version "810.2.817.0" :aws/serviceFullName "Amazon Simple Systems Manager (SSM)"}
+        com.cognitect.aws/sso                             {:mvn/version "770.2.568.0" :aws/serviceFullName "AWS Single Sign-On"}
+        com.cognitect.aws/sso-admin                       {:mvn/version "810.2.801.0" :aws/serviceFullName "AWS Single Sign-On Admin"}
+        com.cognitect.aws/sso-oidc                        {:mvn/version "770.2.568.0" :aws/serviceFullName "AWS SSO OIDC"}
+        com.cognitect.aws/states                          {:mvn/version "810.2.801.0" :aws/serviceFullName "AWS Step Functions"}
+        com.cognitect.aws/storagegateway                  {:mvn/version "809.2.797.0" :aws/serviceFullName "AWS Storage Gateway"}
+        com.cognitect.aws/streams-dynamodb                {:mvn/version "809.2.784.0" :aws/serviceFullName "Amazon DynamoDB Streams"}
+        com.cognitect.aws/sts                             {:mvn/version "809.2.784.0" :aws/serviceFullName "AWS Security Token Service"}
+        com.cognitect.aws/support                         {:mvn/version "801.2.700.0" :aws/serviceFullName "AWS Support"}
+        com.cognitect.aws/swf                             {:mvn/version "770.2.568.0" :aws/serviceFullName "Amazon Simple Workflow Service"}
+        com.cognitect.aws/synthetics                      {:mvn/version "809.2.797.0" :aws/serviceFullName "Synthetics"}
+        com.cognitect.aws/textract                        {:mvn/version "809.2.797.0" :aws/serviceFullName "Amazon Textract"}
+        com.cognitect.aws/timestream-query                {:mvn/version "810.2.801.0" :aws/serviceFullName "Amazon Timestream Query"}
+        com.cognitect.aws/timestream-write                {:mvn/version "810.2.801.0" :aws/serviceFullName "Amazon Timestream Write"}
+        com.cognitect.aws/transcribe                      {:mvn/version "809.2.784.0" :aws/serviceFullName "Amazon Transcribe Service"}
+        com.cognitect.aws/transfer                        {:mvn/version "811.2.824.0" :aws/serviceFullName "AWS Transfer Family"}
+        com.cognitect.aws/translate                       {:mvn/version "810.2.801.0" :aws/serviceFullName "Amazon Translate"}
+        com.cognitect.aws/waf                             {:mvn/version "796.2.666.0" :aws/serviceFullName "AWS WAF"}
+        com.cognitect.aws/waf-regional                    {:mvn/version "796.2.666.0" :aws/serviceFullName "AWS WAF Regional"}
+        com.cognitect.aws/wafv2                           {:mvn/version "809.2.784.0" :aws/serviceFullName "AWS WAFV2"}
+        com.cognitect.aws/wellarchitected                 {:mvn/version "810.2.817.0" :aws/serviceFullName "AWS Well-Architected Tool"}
+        com.cognitect.aws/workdocs                        {:mvn/version "793.2.629.0" :aws/serviceFullName "Amazon WorkDocs"}
+        com.cognitect.aws/worklink                        {:mvn/version "801.2.687.0" :aws/serviceFullName "Amazon WorkLink"}
+        com.cognitect.aws/workmail                        {:mvn/version "809.2.784.0" :aws/serviceFullName "Amazon WorkMail"}
+        com.cognitect.aws/workmailmessageflow             {:mvn/version "770.2.568.0" :aws/serviceFullName "Amazon WorkMail Message Flow"}
+        com.cognitect.aws/workspaces                      {:mvn/version "810.2.805.0" :aws/serviceFullName "Amazon WorkSpaces"}
+        com.cognitect.aws/xray                            {:mvn/version "809.2.797.0" :aws/serviceFullName "AWS X-Ray"}}}

--- a/deps.template.edn
+++ b/deps.template.edn
@@ -15,6 +15,4 @@
         babashka/pods {:git/url "https://github.com/babashka/pods"
                        :sha "22f200ef3006da90971e3bafa794985918b65fea"}
         ;; from https://raw.githubusercontent.com/cognitect-labs/aws-api/master/latest-releases.edn
-        {{latest-releases.edn}}
-        }
- }
+        {{latest-releases.edn}}}}


### PR DESCRIPTION
Indent the version to the widest api column.
I think it is much easier to read than previous version.

The output is still the same as previously but with better indentation.

See [deps.edn](https://github.com/burinc/pod-babashka-aws/blob/main/deps.edn) for sample output

Best,
Burin